### PR TITLE
Fixing Events names.

### DIFF
--- a/napps/kytos/of_core/README.rst
+++ b/napps/kytos/of_core/README.rst
@@ -21,12 +21,12 @@ Installing
 ==========
 
 This is a default Kytos Network Application and the installation process is
-straight forward: Just copy the ``kytos/of.core`` directory to your napps
+straight forward: Just copy the ``kytos/of_core`` directory to your napps
 directory. The default path is ``/var/lib/kytos/napps/``.
 
 .. note:: Please note that you must copy from the root of the napp (including
     the ``kyto`` folder). So you will have
-    ``/var/lib/kytos/napps/kytos/of.core`` at the end.
+    ``/var/lib/kytos/napps/kytos/of_core`` at the end.
 
 If you are going to install the whole repository, with all napps, you do not
 have to worry about the above procedings, since all napps will be copied into

--- a/napps/kytos/of_core/main.py
+++ b/napps/kytos/of_core/main.py
@@ -26,7 +26,7 @@ class Main(KycoCoreNApp):
         The setup method is automatically called by the run method.
         Users shouldn't call this method directly.
         """
-        self.name = 'kytos/of.core'
+        self.name = 'kytos/of_core'
         self.execute_as_loop(settings.STATS_INTERVAL)
         self.controller.log_websocket.register_log(log)
 
@@ -50,11 +50,11 @@ class Main(KycoCoreNApp):
         req = StatsRequest(body_type=StatsTypes.OFPST_FLOW, body=body)
         req.pack()
         event = KycoEvent(
-            name='kytos/of.core.messages.out.ofpt_stats_request',
+            name='kytos/of_core.messages.out.ofpt_stats_request',
             content={'message': req, 'destination': switch.connection})
         self.controller.buffers.msg_out.put(event)
 
-    @listen_to('kytos/of.core.messages.in.ofpt_stats_reply')
+    @listen_to('kytos/of_core.messages.in.ofpt_stats_reply')
     def handle_flow_stats_reply(self, event):
         """Handle flow stats reply message.
 
@@ -73,9 +73,9 @@ class Main(KycoCoreNApp):
                 flows.append(new_flow)
             switch.flows = flows
 
-    @listen_to('kytos/of.core.messages.in.ofpt_features_reply')
+    @listen_to('kytos/of_core.messages.in.ofpt_features_reply')
     def handle_features_reply(self, event):
-        """Handle received kytos/of.core.messages.in.ofpt_features_reply event.
+        """Handle received kytos/of_core.messages.in.ofpt_features_reply event.
 
         Reads the KycoEvent with features reply message sent by the client,
         save this data and sends three new messages to the client:
@@ -129,12 +129,12 @@ class Main(KycoCoreNApp):
         log.debug('RawOpenFlowMessage unpacked')
 
         name = message.header.message_type.name.lower()
-        of_event = KycoEvent(name="kytos/of.core.messages.in.{}".format(name),
+        of_event = KycoEvent(name="kytos/of_core.messages.in.{}".format(name),
                              content={'message': message,
                                       'source': event.source})
         self.controller.buffers.msg_in.put(of_event)
 
-    @listen_to('kytos/of.core.messages.in.ofpt_echo_request')
+    @listen_to('kytos/of_core.messages.in.ofpt_echo_request')
     def handle_echo_request(self, event):
         """Handle Echo Request Messages.
 
@@ -149,13 +149,13 @@ class Main(KycoCoreNApp):
 
         echo_request = event.content['message']
         echo_reply = EchoReply(xid=echo_request.header.xid)
-        event_out = KycoEvent(name=('kytos/of.core.messages.out.'
+        event_out = KycoEvent(name=('kytos/of_core.messages.out.'
                                     'ofpt_echo_reply'),
                               content={'message': echo_reply,
                                        'destination': event.source})
         self.controller.buffers.msg_out.put(event_out)
 
-    @listen_to('kytos/of.core.messages.in.ofpt_hello')
+    @listen_to('kytos/of_core.messages.in.ofpt_hello')
     def handle_openflow_in_hello(self, event):
         """Handle hello messages.
 
@@ -165,17 +165,17 @@ class Main(KycoCoreNApp):
         Args:
             event (KycoMessageInHello): KycoMessageInHelloEvent
         """
-        log.debug('Handling kytos/of.core.messages.ofpt_hello')
+        log.debug('Handling kytos/of_core.messages.ofpt_hello')
 
         # TODO: Evaluate the OpenFlow version that will be used...
         hello = Hello(xid=event.content['message'].header.xid)
-        event_out = KycoEvent(name='kytos/of.core.messages.out.ofpt_hello',
+        event_out = KycoEvent(name='kytos/of_core.messages.out.ofpt_hello',
                               content={'message': hello,
                                        'destination': event.source})
         self.controller.buffers.msg_out.put(event_out)
 
-    @listen_to('kytos/of.core.messages.out.ofpt_hello',
-               'kytos/of.core.messages.out.ofpt_echo_reply')
+    @listen_to('kytos/of_core.messages.out.ofpt_hello',
+               'kytos/of_core.messages.out.ofpt_echo_reply')
     def send_features_request(self, event):
         """Send a feature request to the switch after a hello Message.
 
@@ -189,7 +189,7 @@ class Main(KycoCoreNApp):
         """
         log.debug('Sending a feature request after responding to a hello')
 
-        event_out = KycoEvent(name=('kytos/of.core.messages.out.'
+        event_out = KycoEvent(name=('kytos/of_core.messages.out.'
                                     'ofpt_features_request'),
                               content={'message': FeaturesRequest(),
                                        'destination': event.destination})

--- a/napps/kytos/of_flow_manager/README.rst
+++ b/napps/kytos/of_flow_manager/README.rst
@@ -14,12 +14,12 @@ Installing
 ==========
 
 This is a default Kytos Network Application and the installation process is
-straight forward: Just copy the ``kytos/of.flow-manager`` directory to your
+straight forward: Just copy the ``kytos/of_flow-manager`` directory to your
 napps directory. The default path is ``/var/lib/kytos/napps/``.
 
 .. note:: Please note that you must copy from the root of the napp (including
     the ``kyto`` folder). So you will have
-    ``/var/lib/kytos/napps/kytos/of.flow-manager`` at the end.
+    ``/var/lib/kytos/napps/kytos/of_flow-manager`` at the end.
 
 If you are going to install the whole repository, with all napps, you do not
 have to worry about the above procedings, since all napps will be copied into

--- a/napps/kytos/of_flow_manager/main.py
+++ b/napps/kytos/of_flow_manager/main.py
@@ -126,7 +126,7 @@ class FlowManager(object):
         switch = self.controller.get_switch_by_dpid(dpid)
         flow_mod = flow.as_flow_mod(FlowModCommand.OFPFC_ADD)
 
-        event_out = KycoEvent(name=('kytos/of.flow-manager.messages.out.'
+        event_out = KycoEvent(name=('kytos/of_flow-manager.messages.out.'
                                     'ofpt_flow_mod'),
                               content={'destination': switch.connection,
                                        'message': flow_mod})
@@ -137,7 +137,7 @@ class FlowManager(object):
         switch = self.controller.get_switch_by_dpid(dpid)
         for flow in switch.flows:
             flow_mod = flow.as_flow_mod(FlowModCommand.OFPFC_DELETE)
-            event_out = KycoEvent(name=('kytos/of.flow-manager.messages.out.'
+            event_out = KycoEvent(name=('kytos/of_flow-manager.messages.out.'
                                         'ofpt_flow_mod'),
                                   content={'destination': switch.connection,
                                            'message': flow_mod})
@@ -152,7 +152,7 @@ class FlowManager(object):
                 flow_mod = flow.as_flow_mod(FlowModCommand.OFPFC_DELETE)
                 content = {'destination': switch.connection,
                            'message': flow_mod}
-                event_out = KycoEvent(name=('kytos/of.flow-manager.'
+                event_out = KycoEvent(name=('kytos/of_flow-manager.'
                                             'messages.out.ofpt_flow_mod'),
                                       content=content)
                 self.controller.buffers.msg_out.put(event_out)

--- a/napps/kytos/of_ipv6drop/README.rst
+++ b/napps/kytos/of_ipv6drop/README.rst
@@ -19,12 +19,12 @@ Installing
 ==========
 
 This is a default Kytos Network Application and the installation process is
-straight forward: Just copy the ``kytos/of.ipv6drop`` directory to your napps
+straight forward: Just copy the ``kytos/of_ipv6drop`` directory to your napps
 directory. The default path is ``/var/lib/kytos/napps/``.
 
 .. note:: Please note that you must copy from the root of the napp (including
     the ``kyto`` folder). So you will have
-    ``/var/lib/kytos/napps/kytos/of.ipv6drop`` at the end.
+    ``/var/lib/kytos/napps/kytos/of_ipv6drop`` at the end.
 
 If you are going to install the whole repository, with all napps, you do not
 have to worry about the above procedings, since all napps will be copied into

--- a/napps/kytos/of_ipv6drop/main.py
+++ b/napps/kytos/of_ipv6drop/main.py
@@ -39,7 +39,7 @@ class Main(KycoCoreNApp):
         flow_mod.command = FlowModCommand.OFPFC_ADD
         flow_mod.match = Match()
         flow_mod.match.dl_type = 0x86dd  # ipv6
-        event_out = KycoEvent(name=('kytos/of.ipv6disable.messages.out.'
+        event_out = KycoEvent(name=('kytos/of_ipv6disable.messages.out.'
                                     'ofpt_flow_mod'),
                               content={'destination': switch.connection,
                                        'message': flow_mod})

--- a/napps/kytos/of_l2ls/README.rst
+++ b/napps/kytos/of_l2ls/README.rst
@@ -21,12 +21,12 @@ Installing
 ==========
 
 This is a default Kytos Network Application and the installation process is
-straight forward: Just copy the ``kytos/of.l2ls`` directory to your napps
+straight forward: Just copy the ``kytos/of_l2ls`` directory to your napps
 directory. The default path is ``/var/lib/kytos/napps/``.
 
 .. note:: Please note that you must copy from the root of the napp (including
     the ``kyto`` folder). So you will have
-    ``/var/lib/kytos/napps/kytos/of.l2ls`` at the end.
+    ``/var/lib/kytos/napps/kytos/of_l2ls`` at the end.
 
 If you are going to install the whole repository, with all napps, you do not
 have to worry about the above procedings, since all napps will be copied into

--- a/napps/kytos/of_l2ls/main.py
+++ b/napps/kytos/of_l2ls/main.py
@@ -33,7 +33,7 @@ class Main(KycoCoreNApp):
         """
         pass
 
-    @listen_to('kytos/of.core.messages.in.ofpt_packet_in')
+    @listen_to('kytos/of_core.messages.in.ofpt_packet_in')
     def handle_packet_in(self, event):
         """Handle PacketIn Event.
 
@@ -66,7 +66,7 @@ class Main(KycoCoreNApp):
                 flow_mod.match.dl_type = ethernet.type
                 flow_mod.buffer_id = packet_in.buffer_id
                 flow_mod.actions.append(ActionOutput(port=ports[0]))
-                event_out = KycoEvent(name=('kytos/of.l2ls.messages.out.'
+                event_out = KycoEvent(name=('kytos/of_l2ls.messages.out.'
                                             'ofpt_flow_mod'),
                                       content={'destination': event.source,
                                                'message': flow_mod})
@@ -77,7 +77,7 @@ class Main(KycoCoreNApp):
                 packet_out.in_port = packet_in.in_port
 
                 packet_out.actions.append(ActionOutput(port=Port.OFPP_FLOOD))
-                event_out = KycoEvent(name=('kytos/of.l2ls.messages.out.'
+                event_out = KycoEvent(name=('kytos/of_l2ls.messages.out.'
                                             'ofpt_packet_out'),
                                       content={'destination': event.source,
                                                'message': packet_out})

--- a/napps/kytos/of_l2lsloop/README.rst
+++ b/napps/kytos/of_l2lsloop/README.rst
@@ -18,12 +18,12 @@ Installing
 ==========
 
 This is a default Kytos Network Application and the installation process is
-straight forward: Just copy the ``kytos/of.l2lsloop`` directory to your napps
+straight forward: Just copy the ``kytos/of_l2lsloop`` directory to your napps
 directory. The default path is ``/var/lib/kytos/napps/``.
 
 .. note:: Please note that you must copy from the root of the napp (including
     the ``kyto`` folder). So you will have
-    ``/var/lib/kytos/napps/kytos/of.l2lsloop`` at the end.
+    ``/var/lib/kytos/napps/kytos/of_l2lsloop`` at the end.
 
 If you are going to install the whole repository, with all napps, you do not
 have to worry about the above procedings, since all napps will be copied into

--- a/napps/kytos/of_l2lsloop/main.py
+++ b/napps/kytos/of_l2lsloop/main.py
@@ -28,7 +28,7 @@ class Main(KycoCoreNApp):
         """Do nothing."""
         pass
 
-    @listen_to('kytos/of.core.messages.in.ofpt_packet_in')
+    @listen_to('kytos/of_core.messages.in.ofpt_packet_in')
     def handle_packet_in(self, event):
         """Method to handle flows to allow communication between switch ports.
 
@@ -58,7 +58,7 @@ class Main(KycoCoreNApp):
             flow_mod.buffer_id = packet_in.buffer_id
             flow_mod.actions.append(ActionOutput(port=ports[0]))
 
-            message_name = 'kytos/of.l2ls.messages.out.ofpt_flow_mod'
+            message_name = 'kytos/of_l2ls.messages.out.ofpt_flow_mod'
             content = {'destination': event.source,
                        'message': flow_mod}
             event_out = KycoEvent(name=message_name, content=content)
@@ -73,7 +73,7 @@ class Main(KycoCoreNApp):
 
             switch.update_flood_table(ethernet)
 
-            message_name = 'kytos/of.l2ls.messages.out.ofpt_packet_out'
+            message_name = 'kytos/of_l2ls.messages.out.ofpt_packet_out'
             content = {'destination': event.source,
                        'message': packet_out}
             event_out = KycoEvent(name=message_name,

--- a/napps/kytos/of_lldp/README.rst
+++ b/napps/kytos/of_lldp/README.rst
@@ -12,12 +12,12 @@ Installing
 ==========
 
 This is a default Kytos Network Application and the installation process is
-straight forward: Just copy the ``kytos/of.lldp`` directory to your napps
+straight forward: Just copy the ``kytos/of_lldp`` directory to your napps
 directory. The default path is ``/var/lib/kytos/napps/``.
 
 .. note:: Please note that you must copy from the root of the napp (including
     the ``kyto`` folder). So you will have
-    ``/var/lib/kytos/napps/kytos/of.lldp`` at the end.
+    ``/var/lib/kytos/napps/kytos/of_lldp`` at the end.
 
 If you are going to install the whole repository, with all napps, you do not
 have to worry about the above procedings, since all napps will be copied into

--- a/napps/kytos/of_lldp/main.py
+++ b/napps/kytos/of_lldp/main.py
@@ -21,7 +21,7 @@ class Main(KycoCoreNApp):
 
     def setup(self):
         """Create an empty dict to store the switches references and data."""
-        self.name = 'kytos/of.lldp'
+        self.name = 'kytos/of_lldp'
         self.execute_as_loop(settings.POOLING_TIME)
         self.controller.log_websocket.register_log(log)
 
@@ -55,7 +55,7 @@ class Main(KycoCoreNApp):
                 packet_out.data = ethernet.pack()
 
                 event_out = KycoEvent()
-                event_out.name = 'kytos/of.lldp.messages.out.ofpt_packet_out'
+                event_out.name = 'kytos/of_lldp.messages.out.ofpt_packet_out'
                 event_out.content = {'destination': switch.connection,
                                      'message': packet_out}
                 self.controller.buffers.msg_out.put(event_out)
@@ -63,7 +63,7 @@ class Main(KycoCoreNApp):
                 log.debug("Sending a LLDP PacketOut to the switch %s",
                           switch.dpid)
 
-    @listen_to('kytos/of.core.messages.in.ofpt_packet_in')
+    @listen_to('kytos/of_core.messages.in.ofpt_packet_in')
     def update_links(self, event):
         """Method used to update interfaces when a Ethernet packet is received.
 

--- a/napps/kytos/of_stats/README.rst
+++ b/napps/kytos/of_stats/README.rst
@@ -33,12 +33,12 @@ Installing
 ==========
 
 This is a default Kytos Network Application and the installation process is
-straight forward: Just copy the ``kytos/of.stats`` directory to your napps
+straight forward: Just copy the ``kytos/of_stats`` directory to your napps
 directory. The default path is ``/var/lib/kytos/napps/``.
 
 .. note:: Please note that you must copy from the root of the napp (including
     the ``kyto`` folder). So you will have
-    ``/var/lib/kytos/napps/kytos/of.stats`` at the end.
+    ``/var/lib/kytos/napps/kytos/of_stats`` at the end.
 
 If you are going to install the whole repository, with all napps, you do not
 have to worry about the above procedings, since all napps will be copied into

--- a/napps/kytos/of_stats/main.py
+++ b/napps/kytos/of_stats/main.py
@@ -47,7 +47,7 @@ class Main(KycoNApp):
             if switch.connection is not None:
                 stats.request(switch.connection)
 
-    @listen_to('kytos/of.core.messages.in.ofpt_stats_reply')
+    @listen_to('kytos/of_core.messages.in.ofpt_stats_reply')
     def listener(self, event):
         """Store switch descriptions."""
         msg = event.content['message']

--- a/napps/kytos/of_stats/stats.py
+++ b/napps/kytos/of_stats/stats.py
@@ -42,7 +42,7 @@ class Stats(metaclass=ABCMeta):
 
     def _send_event(self, req, conn):
         event = KycoEvent(
-            name='kytos/of.stats.messages.out.ofpt_stats_request',
+            name='kytos/of_stats.messages.out.ofpt_stats_request',
             content={'message': req, 'destination': conn})
         self._buffer.put(event)
 

--- a/napps/kytos/of_topology/README.rst
+++ b/napps/kytos/of_topology/README.rst
@@ -27,12 +27,12 @@ Installing
 ==========
 
 This is a default Kytos Network Application and the installation process is
-straight forward: Just copy the ``kytos/of.topology`` directory to your napps
+straight forward: Just copy the ``kytos/of_topology`` directory to your napps
 directory. The default path is ``/var/lib/kytos/napps/``.
 
 .. note:: Please note that you must copy from the root of the napp (including
     the ``kyto`` folder). So you will have
-    ``/var/lib/kytos/napps/kytos/of.topology`` at the end.
+    ``/var/lib/kytos/napps/kytos/of_topology`` at the end.
 
 If you are going to install the whole repository, with all napps, you do not
 have to worry about the above procedings, since all napps will be copied into

--- a/napps/kytos/of_topology/main.py
+++ b/napps/kytos/of_topology/main.py
@@ -26,7 +26,7 @@ class Main(KycoCoreNApp):
         This setup will set the name of app, register the endpoint
         /kytos/topology and setup the logger.
         """
-        self.name = 'kytos/of.topology'
+        self.name = 'kytos/of_topology'
         self.controller.register_rest_endpoint('/topology',
                                                self.get_json_topology,
                                                methods=['GET'])
@@ -36,11 +36,11 @@ class Main(KycoCoreNApp):
         """Do nothing, only wait for packet-in messages."""
         pass
 
-    @listen_to('kytos/of.core.messages.in.ofpt_packet_in')
+    @listen_to('kytos/of_core.messages.in.ofpt_packet_in')
     def update_links(self, event):
         """Receive a kytos event and update links interface.
 
-        Get the event kytos/of.core.messages.in.ofpt_packet_in and update
+        Get the event kytos/of_core.messages.in.ofpt_packet_in and update
         the interface endpoints, ignoring the LLDP packages.
 
         Parameters:
@@ -58,11 +58,11 @@ class Main(KycoCoreNApp):
                not interface.is_link_between_switches():
                 interface.update_endpoint(hw_address)
 
-    @listen_to('kytos/of.core.messages.in.ofpt_port_status')
+    @listen_to('kytos/of_core.messages.in.ofpt_port_status')
     def update_port_stats(self, event):
         """Receive a Kytos event and update port.
 
-        Get the event kytos/of.core.messages.in.ofpt_port_status and update the
+        Get the event kytos/of_core.messages.in.ofpt_port_status and update the
         port status.
 
         Parameters:

--- a/napps/kytos/web_topology_layout/README.rst
+++ b/napps/kytos/web_topology_layout/README.rst
@@ -16,12 +16,12 @@ Installing
 ==========
 
 This is a default Kytos Network Application and the installation process is
-straight forward: Just copy the ``kytos/web.topology.layout`` directory to your
+straight forward: Just copy the ``kytos/web_topology_layout`` directory to your
 napps directory. The default path is ``/var/lib/kytos/napps/``.
 
 .. note:: Please note that you must copy from the root of the napp (including
     the ``kyto`` folder). So you will have
-    ``/var/lib/kytos/napps/kytos/web.topology.layout`` at the end.
+    ``/var/lib/kytos/napps/kytos/web_topology_layout`` at the end.
 
 If you are going to install the whole repository, with all napps, you do not
 have to worry about the above procedings, since all napps will be copied into

--- a/napps/kytos/web_topology_layout/main.py
+++ b/napps/kytos/web_topology_layout/main.py
@@ -23,12 +23,12 @@ class Main(KycoCoreNApp):
     """
 
     def setup(self):
-        """Method used to create the web.topology.layout routes.
+        """Method used to create the web_topology_layout routes.
 
         This method will register the routes ['kytos/web/topology/layouts/',
         'web/topology/layouts/<name>'] to save and recover topologies.
         """
-        self.name = 'kytos/web.topology.layout'
+        self.name = 'kytos/web_topology_layout'
         self.current_controller = self.controller
         self.controller.register_rest_endpoint('/web/topology/layouts/',
                                                self.get_topologies,


### PR DESCRIPTION
We started our NApps allowing their names to contain dots, but since we
changed our NApps to be python modules, dots are not allowed on its
names. So, we changed it for underscore, and the KycoEvents names should
follow the NApp name.

FIX #168