### PR TITLE
Fix documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,22 +5,22 @@ Overview
 |Experimental| |Tag| |Release| |License|
 
 
-Network Applications(*NApps*) is part of `Kytos project <https://kytos.io/>`__
-and was developed to be used with it. This repository contain only NApps
+Network Applications(*NApps*) are part of `Kytos project <https://kytos.io/>`__
+and were developed to be used with it. This repository contain only NApps
 developed by Kytos core team.
 
-Beside this Napps, new applications can be developed by third-part and may not
-be maintened by the core team. But of course that we support this and we provide
-a repository infrastructure so you can upload and share your napp.
+Besides these NApps, new applications can be written by third party developers
+and may not be maintained by the core team. Of course, we support this and
+provide a repository infrastructure so everyone can upload and share their
+NApps.
 
-So basically this is a small set of Network Apps that is installed on your
-controller by default. Here you can learn how to enable and disable them as well
-as you will learn what is each one's scope.
+Basically this is a small set of Network Apps that is installed for your Kytos
+controller by default.
 
 Please, feel free to use them as a starting point and reference for your own
-Napps.
+NApps.
 
-.. note:: When a napps have a experimental tag means that this napps doesn't
+.. note:: When a NApp has an experimental tag, it means that the NApp isn't
    working properly yet.
 
 QuickStart
@@ -33,8 +33,8 @@ We are doing a huge effort to make Kytos and its components available on all
 common distros. So, we recommend you to download it from your distro repository.
 
 But if you are trying to test, develop or just want a more recent version of
-our software no problem: Download now, the latest release (it still a beta
-software), from our repository:
+our software, no problem: Download now the latest release (it still a beta
+software) from our repository:
 
 
 First you need to clone *kytos-napps* repository:
@@ -54,18 +54,19 @@ way:
 Configuring
 ***********
 
-After *kytos-napps* installation, this package copy all core napps to
-``/var/lib/kytos/napps/kytos/`` where, by default, all networks applications are
-loaded when your Kytos controller is started.
+After *kytos-napps* installation, this package copies NApps to
+``/var/lib/kytos/napps/`` (your controller's NApps folder is configured to
+point to this directory). Enabled NApps are located in
+``/var/lib/kytos/napps/kytos/`` and are loaded when your Kytos controller is
+started.
 
-Please configure your controller to point to the root of this folder
-(``/var/lib/kytos/napps/`` in order to load theses napps.
-
-You can also feel free to move this folder to another place into your system,
-but please remember to change this on your controller config file. For more
-information please visit the section "Configuration" on the `Kytos's
-Administrator Guide
+Feel free to move this folder to another place in your system, but please
+remember to change this on your controller config file. For more information
+please visit the section "Configuration" on the `Kytos's Administrator Guide
 <https://docs.kytos.io/kytos/administrator/#configuration>`__.
+
+For information about enabling or disabling NApps for the Kytos controller,
+please refer to `kytos-utils <https://github.com/kytos/kytos-napps>`__.
 
 Authors
 *******

--- a/README.rst
+++ b/README.rst
@@ -49,7 +49,7 @@ way:
 .. code-block:: shell
 
    $ cd kytos-napps
-   $ sudo python3 setup.py install
+   $ sudo python3.6 setup.py install
 
 Configuring
 ***********


### PR DESCRIPTION
Correct information about NApps, their location and enabling/disabling.
Correct mispells ad typos, minor changes to text.
Fix #186 
Fix #185 