### PR TITLE
Keep 'author' and 'username' in kytos.json

### DIFF
--- a/napps/kytos/of_core/kytos.json
+++ b/napps/kytos/of_core/kytos.json
@@ -1,4 +1,5 @@
 {
+  "author": "kytos",
   "username": "kytos",
   "name": "of_core",
   "description": "OpenFlow Core of Kytos Controller, responsible for main OpenFlow operations.",

--- a/napps/kytos/of_flow_manager/kytos.json
+++ b/napps/kytos/of_flow_manager/kytos.json
@@ -1,4 +1,5 @@
 {
+  "author": "kytos",
   "username": "kytos",
   "name": "of_flow_manager",
   "description": "NApp that manages switches flows.",

--- a/napps/kytos/of_ipv6drop/kytos.json
+++ b/napps/kytos/of_ipv6drop/kytos.json
@@ -1,4 +1,5 @@
 {
+  "author": "kytos",
   "username": "kytos",
   "name": "of_ipv6drop",
   "description": "Install flows to DROP IPv6 packets on all switches.",

--- a/napps/kytos/of_l2ls/kytos.json
+++ b/napps/kytos/of_l2ls/kytos.json
@@ -1,4 +1,5 @@
 {
+  "author": "kytos",
   "username": "kytos",
   "name": "of_l2ls",
   "description": "An L2 learning switch application for OpenFlow switches.",

--- a/napps/kytos/of_l2lsloop/kytos.json
+++ b/napps/kytos/of_l2lsloop/kytos.json
@@ -1,4 +1,5 @@
 {
+  "author": "kytos",
   "username": "kytos",
   "name": "of_l2lsloop",
   "description": "A L2 learning switch application for openflow switches, with supports topologies with loops.",

--- a/napps/kytos/of_lldp/kytos.json
+++ b/napps/kytos/of_lldp/kytos.json
@@ -1,4 +1,5 @@
 {
+  "author": "kytos",
   "username": "kytos",
   "name": "of_lldp",
   "description": "App responsible by send packet with lldp protocol to network and to discover switches and hosts.",

--- a/napps/kytos/of_stats/kytos.json
+++ b/napps/kytos/of_stats/kytos.json
@@ -1,4 +1,5 @@
 {
+  "author": "kytos",
   "username": "kytos",
   "name": "of_stats",
   "description": "Provide statistics of openflow switches.",

--- a/napps/kytos/of_topology/kytos.json
+++ b/napps/kytos/of_topology/kytos.json
@@ -1,4 +1,5 @@
 {
+  "author": "kytos",
   "username": "kytos",
   "name": "of_topology",
   "description": "A simple app that update links between machines and swithes and return a json with network topology using the route /kytos/topology.",

--- a/napps/kytos/web_topology_layout/kytos.json
+++ b/napps/kytos/web_topology_layout/kytos.json
@@ -1,4 +1,5 @@
 {
+  "author": "kytos",
   "username": "kytos",
   "name": "web_topology_layout",
   "description": "Manage endpoints related to the web interface settings and layout.",


### PR DESCRIPTION
Keep compatibility between versions. In the future, 'author' can be removed, but for now it's necessary.