### PR TITLE
Fix Scrutinizer CI build

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -11,13 +11,13 @@ build:
         redis: false
     dependencies:
         before:
-            - sudo apt-get install -y librrd-dev
-        override:
-            - true
+            - sudo apt-get install --no-install-recommends -y librrd-dev
     tests:
         before:
             - pip install git+git://github.com/kytos/python-openflow.git
-            - pip install git+git://github.com/kytos/kytos.git
+            # Can't install kytos directly because it has an HTTP dependency
+            - pip install git+git://github.com/diraol/watchdog.git
+            - git clone --depth 1 git://github.com/kytos/kytos.git && cd kytos && sed -i 's|.*http.*watchdog.*||' requirements.txt && pip install . && cd - && rm -rf kytos
             - pip install -r requirements.txt -r requirements-dev.txt
         override:
             -

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,6 +9,8 @@ pydocstyle ~= 1.1.1
 pylama ~= 7.3.3
 pylama_pylint ~= 3.0.1
 radon ~= 1.5.0
-tox ~= 2.7.0
 
 coverage >= 4.4.1
+
+# rrdtool is required to resolve imports while testing
+rrdtool ~= 0.1.11


### PR DESCRIPTION
Broke due to watchdog fork dependency. Scrutinizer can't download from
HTTP. Also add rrdtool as developer dependency and remove unused tox.