### PR TITLE
Remove unpack from kytos/of_core/utils.py

### DIFF
--- a/napps/kytos/of_core/main.py
+++ b/napps/kytos/of_core/main.py
@@ -4,6 +4,7 @@ from kytos.core.connection import CONNECTION_STATE
 from kytos.core.flow import Flow
 from kytos.core.helpers import listen_to
 from pyof.foundation.exceptions import UnpackException
+from pyof.utils import unpack, PYOF_VERSION_LIBS
 
 import pyof.v0x01.asynchronous.error_msg
 import pyof.v0x01.common.header
@@ -28,7 +29,7 @@ from napps.kytos.of_core.v0x04 import utils as of_core_v0x04_utils
 from napps.kytos.of_core import settings
 from napps.kytos.of_core.utils import (emit_message_in, emit_message_out,
                                        GenericHello, NegotiationException,
-                                       of_slicer, unpack, pyof_version_libs)
+                                       of_slicer)
 
 
 class Main(KytosNApp):
@@ -202,7 +203,7 @@ class Main(KytosNApp):
                 Event with echo request in message.
         """
 
-        pyof_lib = pyof_version_libs[event.source.protocol.version]
+        pyof_lib = PYOF_VERSION_LIBS[event.source.protocol.version]
         echo_request = event.message
         echo_reply = pyof_lib.symmetric.echo_reply.EchoReply(
             xid=echo_request.header.xid,
@@ -281,7 +282,7 @@ class Main(KytosNApp):
         self.controller.buffers.app.put(event_raw)
 
         version = max(settings.OPENFLOW_VERSIONS)
-        pyof_lib = pyof_version_libs[version]
+        pyof_lib = PYOF_VERSION_LIBS[version]
 
         error_message = pyof_lib.asynchronous.error_msg.ErrorMsg(
             xid=hello_message.header.xid,
@@ -306,7 +307,7 @@ class Main(KytosNApp):
     def send_features_request(self, destination):
         """Send a feature request to the switch."""
         version = destination.protocol.version
-        pyof_lib = pyof_version_libs[version]
+        pyof_lib = PYOF_VERSION_LIBS[version]
         features_request = pyof_lib.controller2switch.\
             features_request.FeaturesRequest()
         self.emit_message_out(destination, features_request)

--- a/napps/kytos/of_core/utils.py
+++ b/napps/kytos/of_core/utils.py
@@ -10,10 +10,6 @@ from kytos.core import KytosEvent, log
 from pyof.foundation.exceptions import PackException, UnpackException
 from pyof.v0x01.common.header import Type as OFPTYPE
 
-pyof_version_libs = {0x01: pyof_01,
-                     0x04: pyof_04}
-
-
 def of_slicer(remaining_data):
     """Slice a raw bytes into OpenFlow packets"""
     data_len = len(remaining_data)
@@ -27,27 +23,6 @@ def of_slicer(remaining_data):
         else:
             break
     return pkts, remaining_data
-
-
-def unpack(packet):
-    """Unpacks the OpenFlow packet and returns a message."""
-    version = _unpack_int(packet[0])
-    try:
-        pyof_lib = pyof_version_libs[version]
-    except KeyError:
-        raise UnpackException('Version not supported')
-
-    try:
-        header = pyof_lib.common.header.Header()
-        header.unpack(packet[:8])
-        message = pyof_lib.common.utils.new_message_from_header(header)
-        binary_data = packet[8:]
-        if binary_data:
-            message.unpack(binary_data)
-        return message
-    except (UnpackException, ValueError) as e:
-        log.info('Could not unpack message: %s', packet)
-        raise UnpackException(e)
 
 
 def _unpack_int(packet, offset=0, size=None):


### PR DESCRIPTION
This change is necessary to run  kytos/of_core with the PR kytos/python-openflow#444.

This change will affect only kytos/of_core. When a new packet is received this packet will be unpacked using the method [unpack](https://github.com/kytos/python-openflow/pull/444/files#diff-0517db042c698cae643a26b66af93c6fR36) from python-openflow.

