### PR TITLE
Change 'not implemented' log INFO to ERROR

### DIFF
--- a/napps/kytos/of_core/v0x04/utils.py
+++ b/napps/kytos/of_core/v0x04/utils.py
@@ -12,7 +12,7 @@ def update_flow_list(controller, switch):
         switch(:class:`~kytos.core.switch.Switch`):
             target to send a stats request.
     """
-    log.info("update_flow_list not implemented yet for OF v0x04")
+    log.error("update_flow_list not implemented yet for OF v0x04")
 
 
 def handle_features_reply(controller, event):


### PR DESCRIPTION
Change log level of 'not implemented' message for it to keep appearing everytime OpenFlow1.3 is used, but emphasizing that the method needs to be implemented.