### PR TITLE
fix of_topology no host->switch link

### DIFF
--- a/napps/kytos/of_topology/main.py
+++ b/napps/kytos/of_topology/main.py
@@ -106,6 +106,10 @@ class Main(KytosNApp):
                         link = {'source': interface.id,
                                 'target': endpoint.value,
                                 'type': 'link'}
+                        link_rev = {'source': endpoint.value,
+                                'target': interface.id,
+                                'type': 'link'}
+
                         host = {"type": 'host',
                                 "id": endpoint.value,
                                 "name": endpoint.value,
@@ -114,6 +118,7 @@ class Main(KytosNApp):
                             nodes.append(host)
                         if not interface.is_link_between_switches():
                             links.append(link)
+                            links.append(link_rev)
                     else:
                         link = {'source': interface.id,
                                 'target': endpoint.id,


### PR DESCRIPTION
This patch is to fix Issue (https://github.com/kytos/legacy/issues/306) I just opened in kytos/legacy repo:



